### PR TITLE
add reference to fix 'dynamic' error

### DIFF
--- a/_posts/2016-07-11-example-of-xamarin-ios-with-cake.md
+++ b/_posts/2016-07-11-example-of-xamarin-ios-with-cake.md
@@ -5,6 +5,13 @@ categories: xamarin ios cakebuild devops
 layout: post
 ---
 ```csharp
+
+// needed to get 'dynamic' to work (Cake.Plist)
+#reference "Microsoft.CSharp.dll"
+
+// then run it with the '-experimental' flag parameter, e.g. 
+// .\build.ps1 -script mycoolapp.iOS.cake -experimental
+
 #addin "Cake.Xamarin"
 #addin "Cake.FileHelpers"
 #addin "Cake.Plist"


### PR DESCRIPTION
...and comments about running this one with the `-experimental` flag on the command line (leastways until Roslyn is standard everywhere)